### PR TITLE
Update to nodent compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,7 @@ With options:
   "plugins": [
     ["fast-async", {
       "env": {
-        "augmentObject": false,
-        "dontMapStackTraces": true,
-        "dontInstallRequireHook": true
+      	"log":false
       },
       "compiler": {
         "promises": true,
@@ -89,12 +87,12 @@ env:{
   dontInstallRequireHook:false // Don't transform all JS files as they are loaded into node (default: true)
 },
 compiler:{
-  promises:true,    // Use nodent's "Promises" mode. Set to false if your execution environment does not support Promises.
-  generators:false  // Transform into 'Generators' (sub-optimal, but it works)
+  promises:true    // Use nodent's "Promises" mode. Set to false if your runtime environment does not support Promises (default: true)
 },
 runtimePattern:null,     // See below
 useRuntimeModule:false  // See below
 ```
+_NB_: As of v6.3.x, the `env` options `augmentObject`,`dontMapStackTraces` and `dontInstallRequireHook:false` are no longer impemented or required. These modified the execution environment of the compiler (as opposed to the runtime environment of the code generated) and consequently had no purpose.
 
 For more information on the compiler options, see [ES7 and Promises](https://github.com/matatbread/nodent#es7-and-promises) in the nodent documentation.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,38 @@
+{
+  "name": "fast-async",
+  "version": "6.3.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "acorn": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw=="
+    },
+    "acorn-es7-plugin": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.7.tgz",
+      "integrity": "sha1-8u4fMiipDurRJF+asZIusucdM2s="
+    },
+    "nodent-compiler": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nodent-compiler/-/nodent-compiler-3.1.0.tgz",
+      "integrity": "sha512-TXbyrC/8nyAJCI1JtYI6aLDqSqoGLu8oY/c8tKaXMuC7Wg3pKFxaCJAxJyKah1P/iZRU/r6RHqbaHVZvZSOb3g==",
+      "requires": {
+        "acorn": "5.1.1",
+        "acorn-es7-plugin": "1.1.7",
+        "source-map": "0.5.6"
+      }
+    },
+    "nodent-runtime": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/nodent-runtime/-/nodent-runtime-3.0.4.tgz",
+      "integrity": "sha1-qAHst7sPbDmmmyTML6Nwz6i0kto="
+    },
+    "source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "fast-async",
-  "version": "6.2.2",
+  "version": "6.3.0",
   "dependencies": {
-    "nodent": ">=3.0.17"
+    "nodent-compiler": ">=3.1.0",
+    "nodent-runtime": ">=3.0.4"
   },
   "description": "fast-async/await transformer Babel plugin",
   "main": "plugin.js",

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+/package-lock.json

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,11 +1,12 @@
 {
   "name": "fast-async-test",
-  "version": "6.1.2",
+  "version": "6.3.0",
   "dependencies": {
-    "babel-cli": "^6.18.0",
-    "babel-core": "^6.10.4",
-    "babel-plugin-syntax-async-functions": "^6.8.0",
-    "colors": "^1.1.2"
+    "babel-cli": "^6.24.1",
+    "babel-core": "^6.25.0",
+    "babel-plugin-syntax-async-functions": "^6.13.0",
+    "colors": "^1.1.2",
+    "nodent": "^3.1.0"
   },
   "description": "fast-async/await transformer Babel plugin - test module",
   "main": "test.js",
@@ -22,7 +23,7 @@
       [
         "..",
         {
-          "spec":true
+          "spec": true
         }
       ]
     ]


### PR DESCRIPTION
Use nodent-compiler, which prevents global pollution when code doesn't …require any runtime support.