### PR TITLE
Fix plugin for Babel v7 beta.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 fast-async
 ==========
 
-'fast-async' is a _Babel v6.x.x_ plugin that implements the ES7 keywords `async` and `await` using syntax transformation
+'fast-async' is a _Babel v6 and v7_ plugin that implements the ES7 keywords `async` and `await` using syntax transformation
 at compile-time, rather than generators.
 
 The main reason for using 'fast-async' as opposed to Babel's default implementation of async/await is

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ Just include the plugin to the babel options. Minimal `.babelrc` example:
 }
 ```
 
+**N.B.:** Starting in Babel v7, you'll need to prefix plugin names that do not begin with the `babel-plugin-` prefix with a `module:` directive:
+
+```js
+{
+  "plugins": ["module:fast-async"]
+}
+```
+
 That's all. Neither `babel-plugin-transform-runtime` nor `babel-polyfill` required. Your application, once compiled, will probably needs nodent's runtime = see [below](#runtimepattern).
 
 With options:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,35 +4,69 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/helper-module-imports": {
+      "version": "7.0.0-beta.39",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.39.tgz",
+      "integrity": "sha512-9rX3HHqjq1ZIeZgfUm9HEfZc3A/HzjCwnRHn611h0Ou936o81e7ple/NBl0nHLSI1jcJxep8Cp0hNExhM8klJg==",
+      "requires": {
+        "@babel/types": "7.0.0-beta.39",
+        "lodash": "4.17.5"
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.39",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.39.tgz",
+      "integrity": "sha512-wrEe0z4kFP0KbFz8aHbPOGQal0gn+J2Iv9ZJGYbD77JN4BpavbF5l/BvLNZ0Omn665VENncoLVmQpclMbh64sQ==",
+      "requires": {
+        "esutils": "2.0.2",
+        "lodash": "4.17.5",
+        "to-fast-properties": "2.0.0"
+      }
+    },
     "acorn": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw=="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+      "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ=="
     },
     "acorn-es7-plugin": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.7.tgz",
       "integrity": "sha1-8u4fMiipDurRJF+asZIusucdM2s="
     },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+    },
     "nodent-compiler": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/nodent-compiler/-/nodent-compiler-3.1.0.tgz",
-      "integrity": "sha512-TXbyrC/8nyAJCI1JtYI6aLDqSqoGLu8oY/c8tKaXMuC7Wg3pKFxaCJAxJyKah1P/iZRU/r6RHqbaHVZvZSOb3g==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/nodent-compiler/-/nodent-compiler-3.1.7.tgz",
+      "integrity": "sha512-sUFRHCLj7h0eiRkf1NDROduaww+e6hkJCTRHMSwIIO50VHq3OsXa3fR5pPX5GoCMIATxS4fXj/jsM2y3us5BXg==",
       "requires": {
-        "acorn": "5.1.1",
+        "acorn": "5.4.1",
         "acorn-es7-plugin": "1.1.7",
-        "source-map": "0.5.6"
+        "source-map": "0.5.7"
       }
     },
     "nodent-runtime": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/nodent-runtime/-/nodent-runtime-3.0.4.tgz",
-      "integrity": "sha1-qAHst7sPbDmmmyTML6Nwz6i0kto="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nodent-runtime/-/nodent-runtime-3.2.0.tgz",
+      "integrity": "sha512-vpc9vNZmLiTgQO/0ecoX0rogUSikHRj6hPTCO4pW0cJQiozdhhfxsb3TfNi9pzrpNVG71c7oXWRocbfdvkuhWw=="
     },
     "source-map": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "fast-async",
   "version": "6.3.0",
   "dependencies": {
-    "nodent-compiler": ">=3.1.0",
-    "nodent-runtime": ">=3.0.4"
+    "@babel/helper-module-imports": "^7.0.0-beta.39",
+    "nodent-compiler": ">=3.1.7",
+    "nodent-runtime": ">=3.2.0"
   },
   "description": "fast-async/await transformer Babel plugin",
   "main": "plugin.js",


### PR DESCRIPTION
Uses the new Babel module imports helper to `require` the runtime package when `useRuntimeModule` is set. I've verified in a couple of my own projects that this fixes the plugin for the Babel v7 beta, and as the benchmarks still run I believe it should be backwards-compatible with v6 as well.